### PR TITLE
Add K6ModPath to BuildInfo

### DIFF
--- a/foundry.go
+++ b/foundry.go
@@ -25,6 +25,7 @@ type Warning struct {
 // BuildInfo describes the binary
 type BuildInfo struct {
 	Platform    string
+	K6ModPath   string
 	ModVersions map[string]string
 	Warnings    []Warning
 }

--- a/native.go
+++ b/native.go
@@ -148,7 +148,7 @@ func (b *native) Build(
 	if err != nil {
 		return nil, fmt.Errorf("determining k6 module path: %w", err)
 	}
-
+	buildInfo.K6ModPath = k6ModPath
 	b.log.Info("Creating k6 main")
 	err = b.createMain(ctx, workDir, k6ModPath)
 	if err != nil {

--- a/native_test.go
+++ b/native_test.go
@@ -94,7 +94,8 @@ func TestBuild(t *testing.T) {
 			mods:        []Module{},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6": "v0.1.0",
 				},
@@ -106,7 +107,8 @@ func TestBuild(t *testing.T) {
 			mods:        []Module{},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6": "v0.2.0",
 				},
@@ -125,7 +127,8 @@ func TestBuild(t *testing.T) {
 			mods:        []Module{},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6": "v0.3.0",
 				},
@@ -139,7 +142,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":    "v0.1.0",
 					"go.k6.io/k6ext": "v0.1.0",
@@ -154,7 +158,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":    "v0.1.0",
 					"go.k6.io/k6ext": "v0.2.0",
@@ -177,7 +182,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":       "v0.2.0",
 					"go.k6.io/k6ext/v2": "v2.0.0",
@@ -193,7 +199,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":    "v0.1.0",
 					"go.k6.io/k6ext": "v0.0.0-00010101000000-000000000000",
@@ -234,7 +241,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":       "v0.1.0",
 					"private.io/k6ext2": "v0.0.0-00010101000000-000000000000",
@@ -250,7 +258,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6": "v0.1.0",
 					// the goproxy will not serve this module
@@ -269,7 +278,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":       "v0.1.0",
 					"go.k6.io/k6ext":    "v0.1.0",
@@ -286,7 +296,8 @@ func TestBuild(t *testing.T) {
 			},
 			expectError: nil,
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":    "v0.1.0",
 					"go.k6.io/k6ext": "v0.1.0",
@@ -298,7 +309,8 @@ func TestBuild(t *testing.T) {
 			k6Version: "v2.0.0",
 			mods:      []Module{},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6/v2",
 				ModVersions: map[string]string{
 					"go.k6.io/k6/v2": "v2.0.0",
 				},
@@ -310,7 +322,8 @@ func TestBuild(t *testing.T) {
 			k6MajorVersion: "v2",
 			mods:           []Module{},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6/v2",
 				ModVersions: map[string]string{
 					"go.k6.io/k6/v2": "v2.1.0",
 				},
@@ -323,7 +336,8 @@ func TestBuild(t *testing.T) {
 				{Path: "go.k6.io/k6ext", Version: "v0.1.0"},
 			},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6/v2",
 				ModVersions: map[string]string{
 					"go.k6.io/k6/v2": "v2.0.0",
 					"go.k6.io/k6ext": "v0.1.0",
@@ -432,7 +446,8 @@ func TestBuildVersionedExtensions(t *testing.T) {
 			k6Version: "v0.1.0",
 			mods:      []Module{{Path: "go.k6.io/k6extforv1", Version: "v0.1.0"}},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":         "v0.1.0",
 					"go.k6.io/k6extforv1": "v0.1.0",
@@ -445,7 +460,8 @@ func TestBuildVersionedExtensions(t *testing.T) {
 			k6Version: "v2.0.0",
 			mods:      []Module{{Path: "go.k6.io/k6extforv2", Version: "v0.1.0"}},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6/v2",
 				ModVersions: map[string]string{
 					"go.k6.io/k6/v2":      "v2.0.0",
 					"go.k6.io/k6extforv2": "v0.1.0",
@@ -462,7 +478,8 @@ func TestBuildVersionedExtensions(t *testing.T) {
 			k6Version: "v2.0.0",
 			mods:      []Module{{Path: "go.k6.io/k6extforv1", Version: "v0.1.0"}},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6/v2",
 				ModVersions: map[string]string{
 					"go.k6.io/k6/v2":      "v2.0.0",
 					"go.k6.io/k6extforv1": "v0.1.0",
@@ -477,7 +494,8 @@ func TestBuildVersionedExtensions(t *testing.T) {
 			k6Version: "v0.1.0",
 			mods:      []Module{{Path: "go.k6.io/k6extforv2", Version: "v0.1.0"}},
 			expect: &BuildInfo{
-				Platform: "linux/amd64",
+				Platform:  "linux/amd64",
+				K6ModPath: "go.k6.io/k6",
 				ModVersions: map[string]string{
 					"go.k6.io/k6":         "v0.1.0",
 					"go.k6.io/k6extforv2": "v0.1.0",


### PR DESCRIPTION
## Summary

- Add `K6ModPath string` field to `BuildInfo` to expose the exact k6 module path used to generate `main.go`
- Set the field in `native.Build` right after the path is resolved, before `createMain` is called

## Motivation

Callers were previously forced to guess the k6 module path by scanning `ModVersions` (a `map[string]string`), which has non-deterministic iteration order. If multiple k6 major versions were present in the map (e.g. both `go.k6.io/k6` and `go.k6.io/k6/v2`), the wrong one could be returned at random.

## Test plan

- [ ] Existing unit tests pass
- [ ] Callers can now read `BuildInfo.K6ModPath` directly instead of iterating the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)