### PR TITLE
feat: add linux/s390x and zos/s390x to supported platforms

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -62,8 +62,10 @@ func SupportedPlatforms() []Platform {
 var supported = []Platform{ //nolint:gochecknoglobals
 	{OS: "linux", Arch: "amd64"},
 	{OS: "linux", Arch: "arm64"},
+	{OS: "linux", Arch: "s390x"},
 	{OS: "windows", Arch: "amd64"},
 	{OS: "windows", Arch: "arm64"},
 	{OS: "darwin", Arch: "amd64"},
 	{OS: "darwin", Arch: "arm64"},
+	{OS: "zos", Arch: "s390x"},
 }


### PR DESCRIPTION
`linux/s390x` and `zos/s390x` are both valid Go build targets but are currently rejected by `ParsePlatform`, causing `k6 x` subcommands to fail with `invalid build parameters: invalid platform` on s390x hardware.

`linux/s390x` is a standard cross-compilation target alongside the existing `linux/arm64`. `zos/s390x` supports self-hosted k6build deployments on IBM z/OS, where there is an active community port via [zopencommunity/k6port](https://github.com/zopencommunity/k6port).