### PR TITLE
chore: align go directive and toolchain to 1.25.0 / 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/grafana/k6foundry
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require golang.org/x/mod v0.36.0


### PR DESCRIPTION
## Summary
Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.

## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes